### PR TITLE
[feature] semver type: date / email / url

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@zcorky/schema",
-  "version": "1.0.3",
+  "version": "1.0.4",
   "description": "Object schema validation written with TypeScript, inspired by dayjs and schema",
   "main": "lib/index.js",
   "repository": "https://github.com/zcorky/schema",

--- a/src/types/string.ts
+++ b/src/types/string.ts
@@ -1,4 +1,4 @@
-import { string } from '@zcorky/is';
+import { string, date } from '@zcorky/is';
 
 import { Type } from '../core/type';
 import { assert } from '../utils';
@@ -43,6 +43,31 @@ export default class extends Type<string> {
     this.addValidator(assert(
       (v: string) => v.length === limit,
       `{path} with value "{value}" length must be ${limit} characters long`,
+    ));
+    return this;
+  }
+
+  // functional
+  public date() {
+    this.addValidator(assert(
+      (v: string) => date(v),
+      `{path} with value "{value}" must be a date`,
+    ));
+    return this;
+  }
+
+  public email() {
+    this.addValidator(assert(
+      (v: string) => /\w+([-+.]\w+)*@\w+([-.]\w+)*\.\w+([-.]\w+)*/.test(v),
+      `{path} with value "{value}" must be a email`,
+    ));
+    return this;
+  }
+
+  public url() {
+    this.addValidator(assert(
+      (v: string) => /^https?:\/\/(([a-zA-Z0-9_-])+(\.)?)*(:\d+)?(\/((\.)?(\?)?=?&?[a-zA-Z0-9_-](\?)?)*)*$/i.test(v),
+      `{path} with value "{value}" must be a url`,
     ));
     return this;
   }

--- a/test/business/date.spec.ts
+++ b/test/business/date.spec.ts
@@ -1,0 +1,24 @@
+
+import * as Types from '../../src';
+
+describe('date', () => {
+  it('2019-03-31', () => {
+    expect(() => Types.validate(new Types.string().date(), '2019-03-31')).not.toThrow();
+  });
+
+  it('2019/03/31', () => {
+    expect(() => Types.validate(new Types.string().date(), '2019/03/31')).not.toThrow();
+  });
+
+  it('03/31/2019', () => {
+    expect(() => Types.validate(new Types.string().date(), '03/31/2019')).not.toThrow();
+  });
+
+  it('20190331', () => {
+    expect(() => Types.validate(new Types.string().date(), '20190331')).toThrow(/date/);
+  });
+
+  it('201903311', () => {
+    expect(() => Types.validate(new Types.string().date(), '201903311')).toThrow(/date/);
+  });
+});

--- a/test/business/email.spec.ts
+++ b/test/business/email.spec.ts
@@ -1,0 +1,20 @@
+
+import * as Types from '../../src';
+
+describe('email', () => {
+  it('tobewhatwewant@gmail.com', () => {
+    expect(() => Types.validate(new Types.string().email(), 'tobewhatwewant@gmail.com')).not.toThrow();
+  });
+
+  it('tobewhatwewant@gmail.com.cn', () => {
+    expect(() => Types.validate(new Types.string().email(), 'tobewhatwewant@gmail.com.cn')).not.toThrow();
+  });
+
+  it('tobewhatwewant', () => {
+    expect(() => Types.validate(new Types.string().email(), 'tobewhatwewant')).toThrow(/email/);
+  });
+
+  it('tobewhatwewant@gmail', () => {
+    expect(() => Types.validate(new Types.string().email(), 'tobewhatwewant@gmail')).toThrow(/email/);
+  });
+});

--- a/test/business/url.spec.ts
+++ b/test/business/url.spec.ts
@@ -1,0 +1,20 @@
+
+import * as Types from '../../src';
+
+describe('url', () => {
+  it('http://moeover.com', () => {
+    expect(() => Types.validate(new Types.string().url(), 'http://moeover.com')).not.toThrow();
+  });
+
+  it('https://moeover.com', () => {
+    expect(() => Types.validate(new Types.string().url(), 'https://moeover.com')).not.toThrow();
+  });
+
+  it('https://moeover', () => {
+    expect(() => Types.validate(new Types.string().url(), 'https://moeover')).not.toThrow();
+  });
+
+  it('moeover.com', () => {
+    expect(() => Types.validate(new Types.string().url(), 'moeover.com')).toThrow(/url/);
+  });
+});


### PR DESCRIPTION
:sparkles:(Types.string.business): support more common business types
    
- `date()`: valid date, like 2019-03-31, 2019/03/31, but not 20190331
- `email()`: valid email
- `url()`: valid url
    
issue: #18