### PR TITLE
[feature] support custom named error message

### DIFF
--- a/src/core/constants.ts
+++ b/src/core/constants.ts
@@ -1,0 +1,5 @@
+export const DEFAULT_OPTIONS = {
+  name: 'api',
+  description: 'no description',
+  path: 'root',
+};

--- a/src/core/interface.ts
+++ b/src/core/interface.ts
@@ -1,0 +1,5 @@
+export interface IOptions {
+  path?: string;
+  name?: string;
+  description?: string;
+}

--- a/src/core/type.ts
+++ b/src/core/type.ts
@@ -1,13 +1,16 @@
 import { undef as isUndefined } from '@zcorky/is';
+import { IOptions } from './interface';
 import { assert } from '../utils';
 
 export interface IType<T> {
   required(): this;
-  // default(value: T): this;
-  // oneOf(...args: T[]): this;
+  optional(): this;
+  default(value: T): this;
+  oneOf(values: T[]): this;
+  enum(values: T[]): this;
 }
 
-export type IValidator<T> = (key: string, value: T) => void;
+export type IValidator<T> = (key: string, value: T, options?: IOptions) => void;
 
 export abstract class Type<T> implements IType<T> {
   private meta = {
@@ -21,7 +24,7 @@ export abstract class Type<T> implements IType<T> {
     if (!this.meta.hasOwnProperty(name)) {
       throw new Error('Illegal call is with name: ' + name);
     }
-    
+
     return this.meta[name];
   }
 
@@ -60,7 +63,7 @@ export abstract class Type<T> implements IType<T> {
   public oneOf(values: T[]) {
     this.addValidator(assert(
       (v: any) => values.some(e => e === v),
-      `{path} is one of [${values.join(',')}]`,
+      `[{name}] {path} is one of [${values.join(',')}]`,
     ));
 
     return this;
@@ -70,9 +73,9 @@ export abstract class Type<T> implements IType<T> {
     return this.oneOf(values);
   }
 
-  public validate(path: string, value: any) {
+  public validate(path: string, value: any, options?: IOptions) {
     this.validators.forEach(validator => {
-      validator(path, value);
+      validator(path, value, options);
     });
 
     return value;

--- a/src/types/array.ts
+++ b/src/types/array.ts
@@ -11,7 +11,7 @@ export default class <T> extends Type<T> {
   }
 
   public type() {
-    this.addValidator(assert(array, '{path} should be array'));
+    this.addValidator(assert(array, '[{name}] {path} should be array'));
     return this;
   }
 

--- a/src/types/boolean.ts
+++ b/src/types/boolean.ts
@@ -11,7 +11,7 @@ export default class extends Type<boolean> {
   }
 
   public type() {
-    this.addValidator(assert(boolean, '{path} should be boolean'));
+    this.addValidator(assert(boolean, '[{name}] {path} should be boolean'));
     return this;
   }
 }

--- a/src/types/number.ts
+++ b/src/types/number.ts
@@ -11,14 +11,14 @@ export default class extends Type<number> {
   }
 
   public type() {
-    this.addValidator(assert(number, '{path} should be number'));
+    this.addValidator(assert(number, '[{name}] {path} should be number'));
     return this;
   }
 
   public min(limit: number) {
     this.addValidator(assert(
       (v: number) => v >= limit,
-      `{path} with value "{value}" must be greater than or equal to ${limit}`,
+      `[{name}] {path} with value "{value}" must be greater than or equal to ${limit}`,
     ));
     return this;
   }
@@ -26,7 +26,7 @@ export default class extends Type<number> {
    public max(limit: number) {
     this.addValidator(assert(
       (v: number) => v <= limit,
-      `{path} with value "{value}" must be less than or equal to ${limit}`,
+      `[{name}] {path} with value "{value}" must be less than or equal to ${limit}`,
     ));
     return this;
   }
@@ -34,7 +34,7 @@ export default class extends Type<number> {
   public greater(limit: number) {
     this.addValidator(assert(
       (v: number) => v > limit,
-      `{path} with value "{value}" must be greater than ${limit}`,
+      `[{name}] {path} with value "{value}" must be greater than ${limit}`,
     ));
     return this;
   }
@@ -42,7 +42,7 @@ export default class extends Type<number> {
    public less(limit: number) {
     this.addValidator(assert(
       (v: number) => v < limit,
-      `{path} with value "{value}" must be less than ${limit}`,
+      `[{name}] {path} with value "{value}" must be less than ${limit}`,
     ));
     return this;
   }

--- a/src/types/object.ts
+++ b/src/types/object.ts
@@ -15,7 +15,7 @@ class Objectx<T extends object> extends Type<T> implements IObject<T> {
   }
 
   public type() {
-    this.addValidator(assert(object, '{path} should be object'));
+    this.addValidator(assert(object, '[{name}] {path} should be object'));
     return this;
   }
 

--- a/src/types/string.ts
+++ b/src/types/string.ts
@@ -11,14 +11,14 @@ export default class extends Type<string> {
   }
 
   public type() {
-    this.addValidator(assert(string, '{path} should be string'));
+    this.addValidator(assert(string, '[{name}] {path} should be string'));
     return this;
   }
 
   public regex(re: RegExp, message?: string) {
     this.addValidator(assert(
       (v: string) => re.test(v),
-      string(message) ? String(message) : `{path} with value "{value}" fails to match pattern: ${re.toString()}`,
+      string(message) ? String(message) : `[{name}] {path} with value "{value}" fails to match pattern: ${re.toString()}`,
     ));
     return this;
   }
@@ -26,7 +26,7 @@ export default class extends Type<string> {
   public min(limit: number) {
     this.addValidator(assert(
       (v: string) => v.length >= limit,
-      `{path} with value "{value}" length must be at least ${limit} characters long`,
+      `[{name}] {path} with value "{value}" length must be at least ${limit} characters long`,
     ));
     return this;
   }
@@ -34,7 +34,7 @@ export default class extends Type<string> {
   public max(limit: number) {
     this.addValidator(assert(
       (v: string) => v.length <= limit,
-      `{path} with value "{value}" length must be less than or equal to ${limit} characters long`,
+      `[{name}] {path} with value "{value}" length must be less than or equal to ${limit} characters long`,
     ));
     return this;
   }
@@ -42,7 +42,7 @@ export default class extends Type<string> {
   public length(limit: number) {
     this.addValidator(assert(
       (v: string) => v.length === limit,
-      `{path} with value "{value}" length must be ${limit} characters long`,
+      `[{name}] {path} with value "{value}" length must be ${limit} characters long`,
     ));
     return this;
   }
@@ -51,7 +51,7 @@ export default class extends Type<string> {
   public date() {
     this.addValidator(assert(
       (v: string) => date(v),
-      `{path} with value "{value}" must be a date`,
+      `[{name}] {path} with value "{value}" must be a date`,
     ));
     return this;
   }
@@ -59,7 +59,7 @@ export default class extends Type<string> {
   public email() {
     this.addValidator(assert(
       (v: string) => /\w+([-+.]\w+)*@\w+([-.]\w+)*\.\w+([-.]\w+)*/.test(v),
-      `{path} with value "{value}" must be a email`,
+      `[{name}] {path} with value "{value}" must be a email`,
     ));
     return this;
   }
@@ -67,7 +67,7 @@ export default class extends Type<string> {
   public url() {
     this.addValidator(assert(
       (v: string) => /^https?:\/\/(([a-zA-Z0-9_-])+(\.)?)*(:\d+)?(\/((\.)?(\?)?=?&?[a-zA-Z0-9_-](\?)?)*)*$/i.test(v),
-      `{path} with value "{value}" must be a url`,
+      `[{name}] {path} with value "{value}" must be a url`,
     ));
     return this;
   }

--- a/src/utils/index.ts
+++ b/src/utils/index.ts
@@ -1,9 +1,25 @@
+import { DEFAULT_OPTIONS } from './../core/constants';
 import { format } from '@zodash/format';
 
+import { IOptions } from '../core/interface';
+
 export const assert = <T>(fn: (v: T) => boolean, message: string) => {
-  return (path: string, value: T) => {
+  return (path: string, value: T, options: IOptions) => {
     if (!fn(value)) {
-      throw new Error(format(message, { path, value }));
+      const name = options && options.name || DEFAULT_OPTIONS.name;
+
+      const msg = format(message, {
+        ...options,
+        name,
+        path,
+        value,
+      });
+
+      const error = new Error(msg);
+      // error.detail = {}
+      // error.options = options;
+
+      throw error;
     }
   };
 }

--- a/test/semver/named.spec.ts
+++ b/test/semver/named.spec.ts
@@ -1,0 +1,59 @@
+import * as Types from '../../src';
+
+describe('named', () => {
+  const id = new Types.object({
+    id: new Types.string().required(),
+  }).required();
+
+  const entity = new Types.object({
+    title: new Types.string().required(),
+    description: new Types.string(),
+    content: new Types.string().required(),
+    category: new Types.string().enum(['cat1', 'cat2']).required(),
+    comments: new Types.array(new Types.object({
+      id: new Types.string().required(),
+      user: new Types.object({
+        id: new Types.string().required(),
+        nickname: new Types.string().required(),
+        createdAt: new Types.string().required(),
+      }).required(),
+    }).required()).required(),
+  }).required();
+
+  const getPost = {
+    input: id,
+    output: Types.compose(id, entity).required(),
+  };
+
+  it('default', () => {
+    const input = {
+      id: 123,
+    };
+    expect(() => Types.validate(getPost.input, input)).toThrow(/\[api\] root.id\s.*string/);
+
+    // const res = {
+    //   data: { id: 'xxx', title: 'xxx', description: 'xxx', content: 'xxx', category: 'cat3' },
+    // };
+
+    // const output = res.data;
+    // expect(() => Types.validate(getPost.output, output)).toThrow(/root.category\s.*one of \[cat1,cat2\]/);
+  });
+
+  it('custom', () => {
+    const input = {
+      id: 123,
+    };
+    expect(() => Types.validate(getPost.input, input, {
+      name: 'Get Post Request',
+    })).toThrow(/\[Get Post Request] root.id\s.*string/);
+
+    const res = {
+      data: { id: 'xxx', title: 'xxx', description: 'xxx', content: 'xxx', category: 'cat3' },
+    };
+
+    const output = res.data;
+    expect(() => Types.validate(getPost.output, output, {
+      name: 'Get Post Response',
+    })).toThrow(/\[Get Post Response] root.category\s.*one of \[cat1,cat2\]/);
+  });
+});


### PR DESCRIPTION
* format: `[name] [path] ...`
* example

```js
Types.validate(schema, data, {
  name: 'Get Post',
});
// => new Error('[Get Post] root.category is one of [cat1,cat2]')
```