### PR TITLE
(nullable/optional): fix nullable cause type validate does not work

### DIFF
--- a/src/core/type.ts
+++ b/src/core/type.ts
@@ -85,8 +85,8 @@ export abstract class Type<T> implements IType<T> {
   }
 
   public validate(path: string, value: any, options?: IOptions) {
-    if (this.meta.nullable) {
-      return value;
+    if (this.meta.nullable && value === null) {
+      return null;
     }
 
     this.validators.forEach(validator => {

--- a/test/optional.spec.ts
+++ b/test/optional.spec.ts
@@ -12,6 +12,7 @@ describe('optional', () => {
   it('number', () => {
     expect(() => Types.validate(new Types.number().required(), undefined)).toThrow(/required/);
     expect(() => Types.validate(new Types.number(), undefined)).not.toThrow(/required/);
+    expect(() => Types.validate(new Types.number().optional(), '12')).toThrow();
     expect(() => Types.validate(new Types.number().optional(), undefined)).not.toThrow(/required/);
 
     expect(() => Types.validate(new Types.number().optional(), null)).not.toThrow();


### PR DESCRIPTION
`expect(() => Types.validate(new Types.number().optional(), '12')).toThrow()`