### PR TITLE
:bug:(nullable): fix nullable object should not validate the children…

### DIFF
--- a/src/core/validate.ts
+++ b/src/core/validate.ts
@@ -46,6 +46,10 @@ export function validate<S extends ISchema, V>(schema: S, value: V, options?: IO
   if (schemaOf(schema, Types.object)) {
     const v = schema.validate(path, value, options);
 
+    if (schema.getMeta('nullable') && v === null) {
+      return null;
+    }
+
     const o = (schema as any as Types.object<any>);
     return o
       .keys()

--- a/test/nullable.spec.ts
+++ b/test/nullable.spec.ts
@@ -21,8 +21,15 @@ describe('optional', () => {
     expect(() => Types.validate(new Types.object({}).nullable(), null)).not.toThrow();
   });
 
-
   it('array', () => {
     expect(() => Types.validate(new Types.array({}).nullable(), null)).not.toThrow();
+  });
+
+  it('comple object', () => {
+    const schema = new Types.object({
+      id: new Types.string().required(),
+    }).nullable();
+
+    expect(() => Types.validate(schema, null)).not.toThrow();
   });
 });


### PR DESCRIPTION
…, because it was already null, did not have children